### PR TITLE
spell slots per level

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,11 +4,12 @@ import Header from './components/Header'
 import TrackerSegment from './components/TrackerSegment';
 
 //todo logging spending
-//todo spell tracker
 //todo ammo tracker
 //todo weight tracker
 //todo DM vision
 //todo adding widgets
+//todo notes
+//todo removing items
 
 function App() {
 

--- a/src/components/CoinTracker.js
+++ b/src/components/CoinTracker.js
@@ -35,7 +35,7 @@ const CoinTracker = () => {
         var coinCounter = coins
         var coinValue = "You have "
 
-        if(coinCounter > 1000000){ //able to convert to PP
+        if(coinCounter >= 1000000){ //able to convert to PP
             coinValue = coinValue + Math.floor(coinCounter / 1000000) + " PP "
             coinCounter = coinCounter % 1000000
         }
@@ -82,7 +82,7 @@ const CoinTracker = () => {
                         <Button color='gold' text='In GP' textColor='black'  onClick={() => onClickIntialCoinValue(2)}/>
                         <Button color='silver' text='In SP' textColor='black' onClick={() => onClickIntialCoinValue(1)}/>
                         <Button color='#B87333' text='In CP' textColor='black' onClick={() => onClickIntialCoinValue(0)}/> */}
-                        <Button color='gold' text='Submit' textColor='black' onClick={() => onClickIntialCoinValue(0)}/>
+                        <Button text='Submit' onClick={() => onClickIntialCoinValue(0)}/>
                     </div> 
                 :
                     <>

--- a/src/components/SpellCard.js
+++ b/src/components/SpellCard.js
@@ -3,30 +3,22 @@ import 'react-tooltip/dist/react-tooltip.css'
 import { AiOutlineInfoCircle } from 'react-icons/ai'
 
 
-const SpellCard = ({ spellName, spellRange, spellLevel, spellDescription }) => {
-
-  const test = () => {
-    console.log(spellDescription);
-    return spellDescription;
-  }
+const SpellCard = ({ spellName, spellRange, spellLevel, spellDescription, childNum }) => {
 
   return (
     <div className='spell-card'>
         <div align='right'>
-          <AiOutlineInfoCircle id='desc'/>
+          <AiOutlineInfoCircle id={'desc-' + childNum}/>
         </div>
-        <Tooltip anchorId='desc' place='top' className='tooltip'>
+        <Tooltip anchorId={'desc-' + childNum} place='top' className='tooltip'>
           <div>
-            <span id='tooltip'>{ test() }</span>
+            <span id='tooltip'>{ spellDescription }</span>
           </div>
         </Tooltip>
         <h1 align='center'>{ spellName }</h1>
         <div align='center'>
             <h2>{ spellRange }</h2>
             <h2 id='level'>Level { spellLevel } spell</h2>
-            <input type='checkbox' className='big-checkbox'/>
-            <input type='checkbox' className='big-checkbox'/>
-            <input type='checkbox' className='big-checkbox'/>
         </div>
     </div>
   )

--- a/src/components/SpellSlotCard.js
+++ b/src/components/SpellSlotCard.js
@@ -1,0 +1,65 @@
+import React from 'react'
+
+const SpellSlotCard = ({ characterLevel, classType }) => {
+
+  const fullCasterTable = [
+    [2,0,0,0,0,0,0,0,0], [3,0,0,0,0,0,0,0,0], [4,2,0,0,0,0,0,0,0], 
+    [4,3,0,0,0,0,0,0,0], [4,3,2,0,0,0,0,0,0], [4,3,3,0,0,0,0,0,0], 
+    [4,3,3,1,0,0,0,0,0], [4,3,3,2,0,0,0,0,0], [4,3,3,3,1,0,0,0,0], 
+    [4,3,3,3,2,0,0,0,0], [4,3,3,3,2,1,0,0,0], [4,3,3,3,2,1,0,0,0], 
+    [4,3,3,3,2,1,1,0,0], [4,3,3,3,2,1,1,0,0], [4,3,3,3,2,1,1,1,0], 
+    [4,3,3,3,2,1,1,1,0], [4,3,3,3,2,1,1,1,1], [4,3,3,3,3,1,1,1,1], 
+    [4,3,3,3,3,2,1,1,1], [4,3,3,3,3,2,2,1,1], 
+  ]
+  
+  const halfCasterTable = [
+    [0,0,0,0,0], [2,0,0,0,0], [3,0,0,0,0], [3,0,0,0,0], [4,2,0,0,0], 
+    [4,2,0,0,0], [4,3,0,0,0], [4,3,0,0,0], [4,3,2,0,0], [4,3,2,0,0],
+    [4,3,3,0,0], [4,3,3,0,0], [4,3,3,1,0], [4,3,3,1,0], [4,3,3,2,0],
+    [4,3,3,2,0], [4,3,3,3,1], [4,3,3,3,1], [4,3,3,3,2], [4,3,3,3,2]
+  ]
+
+  const fullCasterClasses = ['sorcerer', 'wizard', 'druid', 'bard']
+
+  function determineSpellSlots() {
+    if (fullCasterClasses.includes(classType)) {
+      return fullCasterSlots()
+    } else {
+      return halfCasterSlots()
+    }
+  }
+
+  function fullCasterSlots() {
+    return fullCasterTable[characterLevel-1]
+  }
+
+  function halfCasterSlots() {
+    return halfCasterTable[characterLevel-1]
+  }
+
+  return (
+    <>
+      <h1>Spell Slots</h1>
+      <div className='slots-grid'>
+        {
+          determineSpellSlots().map((x, i) => (
+              (x !== 0 &&
+                <div>
+                  <h2 id='level'>Level {i+1}</h2>
+                  <div className='level-slot'>
+                    {
+                      [...Array(x).keys()].map((y) => (
+                        <input type='checkbox' className='big-checkbox'/>
+                      ))
+                    }
+                  </div>
+                </div>
+              )
+          ))
+        }
+      </div>
+    </>
+  )
+}
+
+export default SpellSlotCard

--- a/src/components/SpellTracker.js
+++ b/src/components/SpellTracker.js
@@ -4,77 +4,139 @@ import 'react-loading-skeleton/dist/skeleton.css'
 import Button from './Button'
 import Dropdown from './Dropdown'
 import SpellCard from './SpellCard'
+import SpellSlotCard from './SpellSlotCard'
 
 const SpellTracker = () => {
 
-    const api_url = "https://www.dnd5eapi.co/"
+    const api_url = "https://www.dnd5eapi.co/";
 
-    const [fetchAll, setFetchAll] = useState(false)
-    const [spellList, setSpellList] = useState([])
-    const [selectedSpells, setSelectedSpells] = useState([])
-    const [spellIndex, setSpellIndex] = useState('')
-    const [spell, setSpell] = useState(null)
-    const [loadingAll, setLoadingAll] = useState(true)
-    // const [loadingSpell, setLoadingSpell] = useState(true)
+    const [fetchAll, setFetchAll] = useState(false);
+    const [loadingAll, setLoadingAll] = useState(true);
+    const [spellList, setSpellList] = useState([{ label: 'Choose Spell...', value: '' }]);
+    const [selectedSpells, setSelectedSpells] = useState([]);
+    const [spellIndex, setSpellIndex] = useState('');
+    const [spell, setSpell] = useState(null);
+    const [classSelected, setClassSelected] = useState(false);
+    const [classList, setClassList] = useState([{ label: 'Choose Class...', value: '' }]);
+    const [playerClass, setPlayerClass] = useState('');
+    const [playerLevel, setPlayerLevel] = useState(1);
 
-    const handleDropdownChange = (event) => {
-        setSpellIndex(event.target.value)
+    const handleSpellDropdownChange = (event) => {
+        setSpellIndex(event.target.value);
     }
 
-    const fetchSpell = async (url, request) => {
-        const res = await fetch(url + request)
-        const recieved = await res.json()
+    const handleClassDropdownChange = (event) => {
+        setPlayerClass(event.target.value);
+    }
 
-        setSelectedSpells(selectedSpells => [...selectedSpells, recieved])
+    const onClickSetPlayerInfo = () => {
+        if (playerClass === ''){
+            alert('Select class');
+        } else {
+            setClassSelected(true);
+        }
+    }
+
+    const clampLevel = (lvl) => {
+        if (lvl >= 20) {
+            setPlayerLevel(20);
+        } else if (lvl < 1) {
+            setPlayerLevel(1);
+        } else {
+            setPlayerLevel(lvl);
+        }
+    }
+
+    // const test = () => {
+    //     let newLvl = playerLevel + 1;
+    //     setPlayerLevel(newLvl);
+    //     console.log(playerLevel);
+    // }
+
+    const fetchSpell = async (url, request) => {
+        const res = await fetch(url + request);
+        const recieved = await res.json();
+
+        setSelectedSpells(selectedSpells => [...selectedSpells, recieved]);
     }
 
     async function getSpellList(url, request) {
-        setLoadingAll(true)
-        const res = await fetch(url + request)
-        const recieved = await res.json()
+        //setLoadingAll(true);
+        const res = await fetch(url + request);
+        const recieved = await res.json();
 
         for (let step = 0; step < recieved['count']; step++) {
-            setSpellList(spellList => [...spellList, ({ label: recieved['results'][step]['name'], value: recieved['results'][step]['index'], url: recieved['results'][step]['url'] })])
+            setSpellList(spellList => [...spellList, ({ label: recieved['results'][step]['name'], value: recieved['results'][step]['index'], url: recieved['results'][step]['url'] })]);
+        }
+        // setFetchAll(true);
+        // setLoadingAll(false);
+    }
+
+    async function getClassList(url, request) {
+        setLoadingAll(true);
+        const res = await fetch(url + request);
+        const recieved = await res.json();
+
+        for (let step = 0; step < recieved['count']; step++) {
+            setClassList(classList => [...classList, ({ label: recieved['results'][step]['name'], value: recieved['results'][step]['index'] })]);
         }
         setFetchAll(true);
-        setLoadingAll(false)
+        setLoadingAll(false);
     }
 
     useEffect(() => {
         if (!fetchAll) {
-            getSpellList(api_url, 'api/spells/')
+            getSpellList(api_url, 'api/spells/');
+            getClassList(api_url, 'api/classes/');
         }
         if (fetchAll && spell) {
-            fetchSpell(api_url, 'api/spells/' + spell)
+            fetchSpell(api_url, 'api/spells/' + spell);
         }
-    }, [fetchAll, spell])
+    }, [fetchAll, spell, playerClass])
 
   return (
     <>
-        <div className='add-form'>
-            <div className='spell-dropdown'>
-                {
-                    loadingAll
-                    ?
-                        <SkeletonTheme baseColor='#484e7b' highlightColor='#515785' height='3em' className='dropdwn'>
-                            <p>
-                                <Skeleton />
-                            </p>
-                        </SkeletonTheme>
-                    :
-                        <Dropdown options={spellList} value={spellIndex} onChange={handleDropdownChange}/>
-                }
-            </div>
-            <Button text='Add' onClick={() => setSpell(spellIndex)} />
-        </div>
-        <div className='spell-grid'>
-            {
-                selectedSpells.map((spell) => (
-                    <SpellCard spellName={spell['name']} spellRange={spell['range']} spellLevel={spell['level']} spellDescription={spell['desc'][0]}/>
-                ))
-            }
-        </div>
-        
+        {
+            !classSelected
+            ?
+                <div className='add-form'>
+                    <div className='class-selector'>
+                        <Dropdown options={classList} value={playerClass} onChange={handleClassDropdownChange}/>
+                        <input placeholder='Level' type='number' onChange={(e) => clampLevel(e.target.value)}/>
+                    </div>
+                    <Button text='Submit' onClick={() => onClickSetPlayerInfo()}/>
+                </div>
+            :
+                <>
+                    {/* <div className='abs'>
+                        <Button text={'Level up!'} onClick={() => test()}/>
+                    </div> */}
+                    <SpellSlotCard characterLevel={playerLevel} classType={playerClass}></SpellSlotCard>
+                    <div className='add-form'>
+                        <div>
+                            {
+                                loadingAll
+                                ?
+                                    <SkeletonTheme baseColor='#484e7b' highlightColor='#515785' height='3em'>
+                                        <p>
+                                            <Skeleton />
+                                        </p>
+                                    </SkeletonTheme>
+                                :
+                                    <Dropdown options={spellList} value={spellIndex} onChange={handleSpellDropdownChange}/>
+                            }
+                        </div>
+                        <Button text='Add' onClick={() => setSpell(spellIndex)} />
+                    </div>
+                    <div className='spell-grid'>
+                        {
+                            selectedSpells.map((spell, i) => (
+                                <SpellCard spellName={spell['name']} spellRange={spell['range']} spellLevel={spell['level']} spellDescription={spell['desc'][0]} childNum={i}/>
+                            ))
+                        }
+                    </div>
+                </>
+        }
     </>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -48,7 +48,6 @@ body {
   grid-template-columns: 1fr 1fr;
 }
 
-
 .ability-grid {
   display: grid;
   grid-auto-flow: row;
@@ -86,8 +85,43 @@ body {
   border-width: 2px;
 }
 
+.class-selector {
+  display: flex;
+  justify-content: center;
+  column-gap: 1em;
+  align-items: center;
+}
+
+.class-selector input {
+  height: 40px;
+  margin: 5px;
+  padding: 3px 7px;
+  font-size: 17px;
+  text-align: center;
+}
+
+.abs {
+  position: absolute;
+  left: 650px;
+  bottom: 700px;
+}
+
+.slots-grid {
+  margin: 2em 0em;
+  display: grid;
+  grid-auto-flow: row;
+  grid-template-columns: 1fr 1fr 1fr;
+  row-gap: 1em;
+}
+
+.level-slot {
+  display: flex;
+  flex-flow: row;
+  justify-content: center;
+}
+
 #level {
-  margin-bottom: 20px;
+  margin-bottom: 1rem;
 }
 
 input.big-checkbox {


### PR DESCRIPTION
- overhauled spell tracker 
    - spell slots by level rather than slot
    - choose class and level to generate spell slots (warlock is weird, haven't done that yet)
    - fixed tooltip issue
- coin tracker shows 1 PP instead of 100 GP when 1 PP is used as initial value
- changed coin tracker button to default button
- css stuff 